### PR TITLE
#7 fix for missing Track node

### DIFF
--- a/lib/tcx.py
+++ b/lib/tcx.py
@@ -103,6 +103,10 @@ class Writer:
         self.add_property(elem, "Cadence", lap.cadence)
         self.add_property(elem, "TriggerMethod", lap.trigger_method)
 
+        self.add_track(elem, activity)
+
+    def add_track(self, element, activity):
+        elem = self.create_element(element, "Track")
         # Add trackpoints
         for w in activity.trackpoints:
             self.add_trackpoint(elem, w)


### PR DESCRIPTION
Hi, I'm not python developer but when I export activity from endomondo manually there is a Track node wrapping Trackpoint nodes, so I added it to your source code.
I hope this fix will help :) Thank you for any additional comments...
